### PR TITLE
add keycloak support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 navbar/
 webapps
+keycloak.json

--- a/app.js
+++ b/app.js
@@ -4,8 +4,9 @@ define([
   'backbone',
   'router',
   'vent',
-  'oh'
-], function($, _, Backbone, Router, vent, oh){
+  'oh',
+  'kc'
+], function($, _, Backbone, Router, vent, oh, kc){
   var initialize = function(){
     vent.on('ohmage:error:auth', function(msg){
       console.log("error from ohmage: "+msg)

--- a/css/nav.css
+++ b/css/nav.css
@@ -127,3 +127,35 @@ body {
 .recaptchatable #recaptcha_response_field {
   height: initial;
 }
+
+.strike {
+    display: block;
+    text-align: center;
+    overflow: hidden;
+    white-space: nowrap; 
+}
+
+.strike > span {
+    position: relative;
+    display: inline-block;
+}
+
+.strike > span:before,
+.strike > span:after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 9999px;
+    height: 1px;
+    background: rgba(0,0,0,.15);
+}
+
+.strike > span:before {
+    right: 100%;
+    margin-right: 10px;
+}
+
+.strike > span:after {
+    left: 100%;
+    margin-left: 10px;
+}

--- a/kc.js
+++ b/kc.js
@@ -1,0 +1,31 @@
+define([
+  'jquery',
+  'underscore',
+  'backbone',
+  'vent',
+  'keycloak'
+], function($, _, Backbone, vent, keycloak){
+  var kc = new Keycloak();
+  kc.init({
+   onLoad: 'check-sso',
+   checkLoginIframeInterval: 1,
+   responseMode: 'query' 
+  }).success(function (authenticated) {
+    if (authenticated) {
+      $.cookie('KEYCLOAK_TOKEN', kc.token);
+      vent.trigger("ohmage:keycloak:token:active");
+    }
+    console.log("Keycloak Authenticated? : "+authenticated);
+  });
+
+  kc.onTokenExpired = function(){
+    console.log("kc token expired called");
+    vent.trigger("ohmage:keycloak:token:expired");  
+  };
+
+  kc.onAuthLogout = function(){
+    vent.trigger("ohmage:error:auth");
+  }
+
+  return kc;
+});

--- a/kc.js
+++ b/kc.js
@@ -8,8 +8,8 @@ define([
   var kc = new Keycloak();
   kc.init({
    onLoad: 'check-sso',
-   checkLoginIframeInterval: 1,
-   responseMode: 'query' 
+   checkLoginIframeInterval: 1
+   //responseMode: 'query' 
   }).success(function (authenticated) {
     if (authenticated) {
       $.cookie('KEYCLOAK_TOKEN', kc.token);

--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1,0 +1,1057 @@
+(function( window, undefined ) {
+
+    var Keycloak = function (config) {
+        if (!(this instanceof Keycloak)) {
+            return new Keycloak(config);
+        }
+
+        var kc = this;
+        var adapter;
+        var refreshQueue = [];
+
+        var loginIframe = {
+            enable: true,
+            callbackMap: [],
+            interval: 5
+        };
+
+        kc.init = function (initOptions) {
+            kc.authenticated = false;
+
+            if (window.Cordova) {
+                adapter = loadAdapter('cordova');
+            } else {
+                adapter = loadAdapter();
+            }
+
+            if (initOptions) {
+                if (typeof initOptions.checkLoginIframe !== 'undefined') {
+                    loginIframe.enable = initOptions.checkLoginIframe;
+                }
+
+                if (initOptions.checkLoginIframeInterval) {
+                    loginIframe.interval = initOptions.checkLoginIframeInterval;
+                }
+
+                if (initOptions.onLoad === 'login-required') {
+                    kc.loginRequired = true;
+                }
+
+                if (initOptions.responseMode) {
+                    if (initOptions.responseMode === 'query' || initOptions.responseMode === 'fragment') {
+                        kc.responseMode = initOptions.responseMode;
+                    } else {
+                        throw 'Invalid value for responseMode';
+                    }
+                }
+
+                if (initOptions.flow) {
+                    switch (initOptions.flow) {
+                        case 'standard':
+                            kc.responseType = 'code';
+                            break;
+                        case 'implicit':
+                            kc.responseType = 'id_token token';
+                            break;
+                        case 'hybrid':
+                            kc.responseType = 'code id_token token';
+                            break;
+                        default:
+                            throw 'Invalid value for flow';
+                    }
+                    kc.flow = initOptions.flow;
+                }
+            }
+
+            if (!kc.responseMode) {
+                kc.responseMode = 'fragment';
+            }
+            if (!kc.responseType) {
+                kc.responseType = 'code';
+                kc.flow = 'standard';
+            }
+
+            var promise = createPromise();
+
+            var initPromise = createPromise();
+            initPromise.promise.success(function() {
+                kc.onReady && kc.onReady(kc.authenticated);
+                promise.setSuccess(kc.authenticated);
+            }).error(function() {
+                promise.setError();
+            });
+
+            var configPromise = loadConfig(config);
+
+            function onLoad() {
+                var doLogin = function(prompt) {
+                    if (!prompt) {
+                        options.prompt = 'none';
+                    }
+                    kc.login(options).success(function () {
+                        initPromise.setSuccess();
+                    }).error(function () {
+                        initPromise.setError();
+                    });
+                }
+
+                var options = {};
+                switch (initOptions.onLoad) {
+                    case 'check-sso':
+                        if (loginIframe.enable) {
+                            setupCheckLoginIframe().success(function() {
+                                checkLoginIframe().success(function () {
+                                    doLogin(false);
+                                }).error(function () {
+                                    initPromise.setSuccess();
+                                });
+                            });
+                        } else {
+                            doLogin(false);
+                        }
+                        break;
+                    case 'login-required':
+                        doLogin(true);
+                        break;
+                    default:
+                        throw 'Invalid value for onLoad';
+                }
+            }
+
+            function processInit() {
+                var callback = parseCallback(window.location.href);
+
+                if (callback) {
+                    setupCheckLoginIframe();
+                    window.history.replaceState({}, null, callback.newUrl);
+                    processCallback(callback, initPromise);
+                    return;
+                } else if (initOptions) {
+                    if (initOptions.token || initOptions.refreshToken) {
+                        setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken, false);
+                        kc.timeSkew = initOptions.timeSkew || 0;
+
+                        if (loginIframe.enable) {
+                            setupCheckLoginIframe().success(function() {
+                                checkLoginIframe().success(function () {
+                                    initPromise.setSuccess();
+                                }).error(function () {
+                                    if (initOptions.onLoad) {
+                                        onLoad();
+                                    }
+                                });
+                            });
+                        } else {
+                            initPromise.setSuccess();
+                        }
+                    } else if (initOptions.onLoad) {
+                        onLoad();
+                    }
+                } else {
+                    initPromise.setSuccess();
+                }
+            }
+
+            configPromise.success(processInit);
+            configPromise.error(function() {
+                promise.setError();
+            });
+
+            return promise.promise;
+        }
+
+        kc.login = function (options) {
+            return adapter.login(options);
+        }
+
+        kc.createLoginUrl = function(options) {
+            var state = createUUID();
+            var nonce = createUUID();
+
+            var redirectUri = adapter.redirectUri(options);
+            if (options && options.prompt) {
+                redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'prompt=' + options.prompt;
+            }
+
+            sessionStorage.oauthState = JSON.stringify({ state: state, nonce: nonce, redirectUri: encodeURIComponent(redirectUri) });
+
+            var action = 'auth';
+            if (options && options.action == 'register') {
+                action = 'registrations';
+            }
+
+            var url = getRealmUrl()
+                + '/protocol/openid-connect/' + action
+                + '?client_id=' + encodeURIComponent(kc.clientId)
+                + '&redirect_uri=' + encodeURIComponent(redirectUri)
+                + '&state=' + encodeURIComponent(state)
+                + '&nonce=' + encodeURIComponent(nonce)
+                + '&response_mode=' + encodeURIComponent(kc.responseMode)
+                + '&response_type=' + encodeURIComponent(kc.responseType);
+
+            if (options && options.prompt) {
+                url += '&prompt=' + encodeURIComponent(options.prompt);
+            }
+
+            if (options && options.loginHint) {
+                url += '&login_hint=' + encodeURIComponent(options.loginHint);
+            }
+
+            if (options && options.idpHint) {
+                url += '&kc_idp_hint=' + encodeURIComponent(options.idpHint);
+            }
+
+            if (options && options.scope) {
+                url += '&scope=' + encodeURIComponent(options.scope);
+            }
+
+            if (options && options.locale) {
+                url += '&ui_locales=' + encodeURIComponent(options.locale);
+            }
+
+            return url;
+        }
+
+        kc.logout = function(options) {
+            return adapter.logout(options);
+        }
+
+        kc.createLogoutUrl = function(options) {
+            var url = getRealmUrl()
+                + '/protocol/openid-connect/logout'
+                + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options));
+
+            return url;
+        }
+
+        kc.register = function (options) {
+            return adapter.register(options);
+        }
+
+        kc.createRegisterUrl = function(options) {
+            if (!options) {
+                options = {};
+            }
+            options.action = 'register';
+            return kc.createLoginUrl(options);
+        }
+
+        kc.createAccountUrl = function(options) {
+            var url = getRealmUrl()
+                + '/account'
+                + '?referrer=' + encodeURIComponent(kc.clientId)
+                + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
+
+            return url;
+        }
+
+        kc.accountManagement = function() {
+            return adapter.accountManagement();
+        }
+
+        kc.hasRealmRole = function (role) {
+            var access = kc.realmAccess;
+            return !!access && access.roles.indexOf(role) >= 0;
+        }
+
+        kc.hasResourceRole = function(role, resource) {
+            if (!kc.resourceAccess) {
+                return false;
+            }
+
+            var access = kc.resourceAccess[resource || kc.clientId];
+            return !!access && access.roles.indexOf(role) >= 0;
+        }
+
+        kc.loadUserProfile = function() {
+            var url = getRealmUrl() + '/account';
+            var req = new XMLHttpRequest();
+            req.open('GET', url, true);
+            req.setRequestHeader('Accept', 'application/json');
+            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+            var promise = createPromise();
+
+            req.onreadystatechange = function () {
+                if (req.readyState == 4) {
+                    if (req.status == 200) {
+                        kc.profile = JSON.parse(req.responseText);
+                        promise.setSuccess(kc.profile);
+                    } else {
+                        promise.setError();
+                    }
+                }
+            }
+
+            req.send();
+
+            return promise.promise;
+        }
+
+        kc.loadUserInfo = function() {
+            var url = getRealmUrl() + '/protocol/openid-connect/userinfo';
+            var req = new XMLHttpRequest();
+            req.open('GET', url, true);
+            req.setRequestHeader('Accept', 'application/json');
+            req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+
+            var promise = createPromise();
+
+            req.onreadystatechange = function () {
+                if (req.readyState == 4) {
+                    if (req.status == 200) {
+                        kc.userInfo = JSON.parse(req.responseText);
+                        promise.setSuccess(kc.userInfo);
+                    } else {
+                        promise.setError();
+                    }
+                }
+            }
+
+            req.send();
+
+            return promise.promise;
+        }
+
+        kc.isTokenExpired = function(minValidity) {
+            if (!kc.tokenParsed || (!kc.refreshToken && kc.flow != 'implicit' )) {
+                throw 'Not authenticated';
+            }
+
+            var expiresIn = kc.tokenParsed['exp'] - (new Date().getTime() / 1000) + kc.timeSkew;
+            if (minValidity) {
+                expiresIn -= minValidity;
+            }
+
+            return expiresIn < 0;
+        }
+
+        kc.updateToken = function(minValidity) {
+            var promise = createPromise();
+
+            if (!kc.tokenParsed || !kc.refreshToken) {
+                promise.setError();
+                return promise.promise;
+            }
+
+            minValidity = minValidity || 5;
+
+            var exec = function() {
+                if (!kc.isTokenExpired(minValidity)) {
+                    promise.setSuccess(false);
+                } else {
+                    var params = 'grant_type=refresh_token&' + 'refresh_token=' + kc.refreshToken;
+                    var url = getRealmUrl() + '/protocol/openid-connect/token';
+
+                    refreshQueue.push(promise);
+
+                    if (refreshQueue.length == 1) {
+                        var req = new XMLHttpRequest();
+                        req.open('POST', url, true);
+                        req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+                        if (kc.clientId && kc.clientSecret) {
+                            req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                        } else {
+                            params += '&client_id=' + encodeURIComponent(kc.clientId);
+                        }
+
+                        var timeLocal = new Date().getTime();
+
+                        req.onreadystatechange = function () {
+                            if (req.readyState == 4) {
+                                if (req.status == 200) {
+                                    timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                                    var tokenResponse = JSON.parse(req.responseText);
+                                    setToken(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], true);
+
+                                    kc.timeSkew = Math.floor(timeLocal / 1000) - kc.tokenParsed.iat;
+
+                                    kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
+                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                        p.setSuccess(true);
+                                    }
+                                } else {
+                                    kc.onAuthRefreshError && kc.onAuthRefreshError();
+                                    for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                                        p.setError(true);
+                                    }
+                                }
+                            }
+                        };
+
+                        req.send(params);
+                    }
+                }
+            }
+
+            if (loginIframe.enable) {
+                var iframePromise = checkLoginIframe();
+                iframePromise.success(function() {
+                    exec();
+                }).error(function() {
+                    promise.setError();
+                });
+            } else {
+                exec();
+            }
+
+            return promise.promise;
+        }
+
+        kc.clearToken = function() {
+            if (kc.token) {
+                setToken(null, null, null, true);
+                kc.onAuthLogout && kc.onAuthLogout();
+                if (kc.loginRequired) {
+                    kc.login();
+                }
+            }
+        }
+
+        function getRealmUrl() {
+            if (kc.authServerUrl.charAt(kc.authServerUrl.length - 1) == '/') {
+                return kc.authServerUrl + 'realms/' + encodeURIComponent(kc.realm);
+            } else {
+                return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
+            }
+        }
+
+        function getOrigin() {
+            if (!window.location.origin) {
+                return window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+            } else {
+                return window.location.origin;
+            }
+        }
+
+        function processCallback(oauth, promise) {
+            var code = oauth.code;
+            var error = oauth.error;
+            var prompt = oauth.prompt;
+
+            var timeLocal = new Date().getTime();
+
+            if (error) {
+                if (prompt != 'none') {
+                    kc.onAuthError && kc.onAuthError();
+                    promise && promise.setError();
+                } else {
+                    promise && promise.setSuccess();
+                }
+                return;
+            } else if ((kc.flow != 'standard') && (oauth.access_token || oauth.id_token)) {
+                authSuccess(oauth.access_token, null, oauth.id_token, true);
+            }
+
+            if ((kc.flow != 'implicit') && code) {
+                var params = 'code=' + code + '&grant_type=authorization_code';
+                var url = getRealmUrl() + '/protocol/openid-connect/token';
+
+                var req = new XMLHttpRequest();
+                req.open('POST', url, true);
+                req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+                if (kc.clientId && kc.clientSecret) {
+                    req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));
+                } else {
+                    params += '&client_id=' + encodeURIComponent(kc.clientId);
+                }
+
+                params += '&redirect_uri=' + oauth.redirectUri;
+
+                req.withCredentials = true;
+
+                req.onreadystatechange = function() {
+                    if (req.readyState == 4) {
+                        if (req.status == 200) {
+
+                            var tokenResponse = JSON.parse(req.responseText);
+                            authSuccess(tokenResponse['access_token'], tokenResponse['refresh_token'], tokenResponse['id_token'], kc.flow === 'standard');
+                        } else {
+                            kc.onAuthError && kc.onAuthError();
+                            promise && promise.setError();
+                        }
+                    }
+                };
+
+                req.send(params);
+            }
+
+            function authSuccess(accessToken, refreshToken, idToken, fulfillPromise) {
+                timeLocal = (timeLocal + new Date().getTime()) / 2;
+
+                setToken(accessToken, refreshToken, idToken, true);
+
+                if ((kc.tokenParsed && kc.tokenParsed.nonce != oauth.storedNonce) ||
+                    (kc.refreshTokenParsed && kc.refreshTokenParsed.nonce != oauth.storedNonce) ||
+                    (kc.idTokenParsed && kc.idTokenParsed.nonce != oauth.storedNonce)) {
+
+                    console.log('invalid nonce!');
+                    kc.clearToken();
+                    promise && promise.setError();
+                } else {
+                    kc.timeSkew = Math.floor(timeLocal / 1000) - kc.tokenParsed.iat;
+
+                    if (fulfillPromise) {
+                        kc.onAuthSuccess && kc.onAuthSuccess();
+                        promise && promise.setSuccess();
+                    }
+                }
+            }
+
+        }
+
+        function loadConfig(url) {
+            var promise = createPromise();
+            var configUrl;
+
+            if (!config) {
+                configUrl = 'keycloak.json';
+            } else if (typeof config === 'string') {
+                configUrl = config;
+            }
+
+            if (configUrl) {
+                var req = new XMLHttpRequest();
+                req.open('GET', configUrl, true);
+                req.setRequestHeader('Accept', 'application/json');
+
+                req.onreadystatechange = function () {
+                    if (req.readyState == 4) {
+                        if (req.status == 200) {
+                            var config = JSON.parse(req.responseText);
+
+                            kc.authServerUrl = config['auth-server-url'];
+                            kc.realm = config['realm'];
+                            kc.clientId = config['resource'];
+                            kc.clientSecret = (config['credentials'] || {})['secret'];
+
+                            promise.setSuccess();
+                        } else {
+                            promise.setError();
+                        }
+                    }
+                };
+
+                req.send();
+            } else {
+                if (!config['url']) {
+                    var scripts = document.getElementsByTagName('script');
+                    for (var i = 0; i < scripts.length; i++) {
+                        if (scripts[i].src.match(/.*keycloak\.js/)) {
+                            config.url = scripts[i].src.substr(0, scripts[i].src.indexOf('/js/keycloak.js'));
+                            break;
+                        }
+                    }
+                }
+
+                if (!config.realm) {
+                    throw 'realm missing';
+                }
+
+                if (!config.clientId) {
+                    throw 'clientId missing';
+                }
+
+                kc.authServerUrl = config.url;
+                kc.realm = config.realm;
+                kc.clientId = config.clientId;
+                kc.clientSecret = (config.credentials || {}).secret;
+
+                promise.setSuccess();
+            }
+
+            return promise.promise;
+        }
+
+        function setToken(token, refreshToken, idToken, useTokenTime) {
+            if (kc.tokenTimeoutHandle) {
+                clearTimeout(kc.tokenTimeoutHandle);
+                kc.tokenTimeoutHandle = null;
+            }
+
+            if (token) {
+                kc.token = token;
+                kc.tokenParsed = decodeToken(token);
+                var sessionId = kc.realm + '/' + kc.tokenParsed.sub;
+                if (kc.tokenParsed.session_state) {
+                    sessionId = sessionId + '/' + kc.tokenParsed.session_state;
+                }
+                kc.sessionId = sessionId;
+                kc.authenticated = true;
+                kc.subject = kc.tokenParsed.sub;
+                kc.realmAccess = kc.tokenParsed.realm_access;
+                kc.resourceAccess = kc.tokenParsed.resource_access;
+
+                if (kc.onTokenExpired) {
+                    var start = useTokenTime ? kc.tokenParsed.iat : (new Date().getTime() / 1000);
+                    var expiresIn = kc.tokenParsed.exp - start;
+                    kc.tokenTimeoutHandle = setTimeout(kc.onTokenExpired, expiresIn * 1000);
+                }
+
+            } else {
+                delete kc.token;
+                delete kc.tokenParsed;
+                delete kc.subject;
+                delete kc.realmAccess;
+                delete kc.resourceAccess;
+
+                kc.authenticated = false;
+            }
+
+            if (refreshToken) {
+                kc.refreshToken = refreshToken;
+                kc.refreshTokenParsed = decodeToken(refreshToken);
+            } else {
+                delete kc.refreshToken;
+                delete kc.refreshTokenParsed;
+            }
+
+            if (idToken) {
+                kc.idToken = idToken;
+                kc.idTokenParsed = decodeToken(idToken);
+            } else {
+                delete kc.idToken;
+                delete kc.idTokenParsed;
+            }
+        }
+
+        function decodeToken(str) {
+            str = str.split('.')[1];
+
+            str = str.replace('/-/g', '+');
+            str = str.replace('/_/g', '/');
+            switch (str.length % 4)
+            {
+                case 0:
+                    break;
+                case 2:
+                    str += '==';
+                    break;
+                case 3:
+                    str += '=';
+                    break;
+                default:
+                    throw 'Invalid token';
+            }
+
+            str = (str + '===').slice(0, str.length + (str.length % 4));
+            str = str.replace(/-/g, '+').replace(/_/g, '/');
+
+            str = decodeURIComponent(escape(atob(str)));
+
+            str = JSON.parse(str);
+            return str;
+        }
+
+        function createUUID() {
+            var s = [];
+            var hexDigits = '0123456789abcdef';
+            for (var i = 0; i < 36; i++) {
+                s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
+            }
+            s[14] = '4';
+            s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
+            s[8] = s[13] = s[18] = s[23] = '-';
+            var uuid = s.join('');
+            return uuid;
+        }
+
+        kc.callback_id = 0;
+
+        function createCallbackId() {
+            var id = '<id: ' + (kc.callback_id++) + (Math.random()) + '>';
+            return id;
+
+        }
+
+        function parseCallback(url) {
+            var oauth = new CallbackParser(url, kc.responseMode).parseUri();
+
+            var sessionState = sessionStorage.oauthState && JSON.parse(sessionStorage.oauthState);
+
+            if (sessionState && (oauth.code || oauth.error || oauth.access_token || oauth.id_token) && oauth.state && oauth.state == sessionState.state) {
+                delete sessionStorage.oauthState;
+
+                oauth.redirectUri = sessionState.redirectUri;
+                oauth.storedNonce = sessionState.nonce;
+
+                if (oauth.fragment) {
+                    oauth.newUrl += '#' + oauth.fragment;
+                }
+
+                return oauth;
+            }
+        }
+
+        function createPromise() {
+            var p = {
+                setSuccess: function(result) {
+                    p.success = true;
+                    p.result = result;
+                    if (p.successCallback) {
+                        p.successCallback(result);
+                    }
+                },
+
+                setError: function(result) {
+                    p.error = true;
+                    p.result = result;
+                    if (p.errorCallback) {
+                        p.errorCallback(result);
+                    }
+                },
+
+                promise: {
+                    success: function(callback) {
+                        if (p.success) {
+                            callback(p.result);
+                        } else if (!p.error) {
+                            p.successCallback = callback;
+                        }
+                        return p.promise;
+                    },
+                    error: function(callback) {
+                        if (p.error) {
+                            callback(p.result);
+                        } else if (!p.success) {
+                            p.errorCallback = callback;
+                        }
+                        return p.promise;
+                    }
+                }
+            }
+            return p;
+        }
+
+        function setupCheckLoginIframe() {
+            var promise = createPromise();
+
+            if (!loginIframe.enable) {
+                promise.setSuccess();
+                return promise.promise;
+            }
+
+            if (loginIframe.iframe) {
+                promise.setSuccess();
+                return promise.promise;
+            }
+
+            var iframe = document.createElement('iframe');
+            loginIframe.iframe = iframe;
+
+            iframe.onload = function() {
+                var realmUrl = getRealmUrl();
+                if (realmUrl.charAt(0) === '/') {
+                    loginIframe.iframeOrigin = getOrigin();
+                } else {
+                    loginIframe.iframeOrigin = realmUrl.substring(0, realmUrl.indexOf('/', 8));
+                }
+                promise.setSuccess();
+
+                setTimeout(check, loginIframe.interval * 1000);
+            }
+
+            var src = getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html?client_id=' + encodeURIComponent(kc.clientId) + '&origin=' + getOrigin();
+            iframe.setAttribute('src', src );
+            iframe.style.display = 'none';
+            document.body.appendChild(iframe);
+
+            var messageCallback = function(event) {
+                if (event.origin !== loginIframe.iframeOrigin) {
+                    return;
+                }
+                var data = JSON.parse(event.data);
+                var promise = loginIframe.callbackMap[data.callbackId];
+                delete loginIframe.callbackMap[data.callbackId];
+
+                if ((!kc.sessionId || kc.sessionId == data.session) && data.loggedIn) {
+                    promise.setSuccess();
+                } else {
+                    kc.clearToken();
+                    promise.setError();
+                }
+            };
+            window.addEventListener('message', messageCallback, false);
+
+            var check = function() {
+                checkLoginIframe();
+                if (kc.token) {
+                    setTimeout(check, loginIframe.interval * 1000);
+                }
+            };
+
+            return promise.promise;
+        }
+
+        function checkLoginIframe() {
+            var promise = createPromise();
+
+            if (loginIframe.iframe && loginIframe.iframeOrigin) {
+                var msg = {};
+                msg.callbackId = createCallbackId();
+                loginIframe.callbackMap[msg.callbackId] = promise;
+                var origin = loginIframe.iframeOrigin;
+                loginIframe.iframe.contentWindow.postMessage(JSON.stringify(msg), origin);
+            } else {
+                promise.setSuccess();
+            }
+
+            return promise.promise;
+        }
+
+        function loadAdapter(type) {
+            if (!type || type == 'default') {
+                return {
+                    login: function(options) {
+                        window.location.href = kc.createLoginUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    logout: function(options) {
+                        window.location.href = kc.createLogoutUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    register: function(options) {
+                        window.location.href = kc.createRegisterUrl(options);
+                        return createPromise().promise;
+                    },
+
+                    accountManagement : function() {
+                        window.location.href = kc.createAccountUrl();
+                        return createPromise().promise;
+                    },
+
+                    redirectUri: function(options) {
+                        if (options && options.redirectUri) {
+                            return options.redirectUri;
+                        } else if (kc.redirectUri) {
+                            return kc.redirectUri;
+                        } else {
+                            var redirectUri = location.href;
+                            if (location.hash) {
+                                redirectUri = redirectUri.substring(0, location.href.indexOf('#'));
+                                redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'redirect_fragment=' + encodeURIComponent(location.hash.substring(1));
+                            }
+                            return redirectUri;
+                        }
+                    }
+                };
+            }
+
+            if (type == 'cordova') {
+                loginIframe.enable = false;
+
+                return {
+                    login: function(options) {
+                        var promise = createPromise();
+
+                        var o = 'location=no';
+                        if (options && options.prompt == 'none') {
+                            o += ',hidden=yes';
+                        }
+
+                        var loginUrl = kc.createLoginUrl(options);
+                        var ref = window.open(loginUrl, '_blank', o);
+
+                        var callback;
+                        var error;
+
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                callback = parseCallback(event.url);
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('loaderror', function(event) {
+                            if (event.url.indexOf('http://localhost') != 0) {
+                                error = true;
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('exit', function(event) {
+                            if (error || !callback) {
+                                promise.setError();
+                            } else {
+                                processCallback(callback, promise);
+                            }
+                        });
+
+                        return promise.promise;
+                    },
+
+                    logout: function(options) {
+                        var promise = createPromise();
+
+                        var logoutUrl = kc.createLogoutUrl(options);
+                        var ref = window.open(logoutUrl, '_blank', 'location=no,hidden=yes');
+
+                        var error;
+
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('loaderror', function(event) {
+                            if (event.url.indexOf('http://localhost') != 0) {
+                                error = true;
+                                ref.close();
+                            }
+                        });
+
+                        ref.addEventListener('exit', function(event) {
+                            if (error) {
+                                promise.setError();
+                            } else {
+                                kc.clearToken();
+                                promise.setSuccess();
+                            }
+                        });
+
+                        return promise.promise;
+                    },
+
+                    register : function() {
+                        var registerUrl = kc.createRegisterUrl();
+                        var ref = window.open(registerUrl, '_blank', 'location=no');
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
+                    },
+
+                    accountManagement : function() {
+                        var accountUrl = kc.createAccountUrl();
+                        var ref = window.open(accountUrl, '_blank', 'location=no');
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
+                    },
+
+                    redirectUri: function(options) {
+                        return 'http://localhost';
+                    }
+                }
+            }
+
+            throw 'invalid adapter type: ' + type;
+        }
+
+
+        var CallbackParser = function(uriToParse, responseMode) {
+            if (!(this instanceof CallbackParser)) {
+                return new CallbackParser(uriToParse, responseMode);
+            }
+            var parser = this;
+
+            var initialParse = function() {
+                var baseUri = null;
+                var queryString = null;
+                var fragmentString = null;
+
+                var questionMarkIndex = uriToParse.indexOf("?");
+                var fragmentIndex = uriToParse.indexOf("#", questionMarkIndex + 1);
+                if (questionMarkIndex == -1 && fragmentIndex == -1) {
+                    baseUri = uriToParse;
+                } else if (questionMarkIndex != -1) {
+                    baseUri = uriToParse.substring(0, questionMarkIndex);
+                    queryString = uriToParse.substring(questionMarkIndex + 1);
+                    if (fragmentIndex != -1) {
+                        fragmentIndex = queryString.indexOf("#");
+                        fragmentString = queryString.substring(fragmentIndex + 1);
+                        queryString = queryString.substring(0, fragmentIndex);
+                    }
+                } else {
+                    baseUri = uriToParse.substring(0, fragmentIndex);
+                    fragmentString = uriToParse.substring(fragmentIndex + 1);
+                }
+
+                return { baseUri: baseUri, queryString: queryString, fragmentString: fragmentString };
+            }
+
+            var parseParams = function(paramString) {
+                var result = {};
+                var params = paramString.split('&');
+                for (var i = 0; i < params.length; i++) {
+                    var p = params[i].split('=');
+                    var paramName = decodeURIComponent(p[0]);
+                    var paramValue = decodeURIComponent(p[1]);
+                    result[paramName] = paramValue;
+                }
+                return result;
+            }
+
+            var handleQueryParam = function(paramName, paramValue, oauth) {
+                var supportedOAuthParams = [ 'code', 'error', 'state' ];
+
+                for (var i = 0 ; i< supportedOAuthParams.length ; i++) {
+                    if (paramName === supportedOAuthParams[i]) {
+                        oauth[paramName] = paramValue;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+
+            parser.parseUri = function() {
+                var parsedUri = initialParse();
+
+                var queryParams = {};
+                if (parsedUri.queryString) {
+                    queryParams = parseParams(parsedUri.queryString);
+                }
+
+                var oauth = { newUrl: parsedUri.baseUri };
+                for (var param in queryParams) {
+                    switch (param) {
+                        case 'redirect_fragment':
+                            oauth.fragment = queryParams[param];
+                            break;
+                        case 'prompt':
+                            oauth.prompt = queryParams[param];
+                            break;
+                        default:
+                            if (responseMode != 'query' || !handleQueryParam(param, queryParams[param], oauth)) {
+                                oauth.newUrl += (oauth.newUrl.indexOf('?') == -1 ? '?' : '&') + param + '=' + queryParams[param];
+                            }
+                            break;
+                    }
+                }
+
+                if (responseMode === 'fragment') {
+                    var fragmentParams = {};
+                    if (parsedUri.fragmentString) {
+                        fragmentParams = parseParams(parsedUri.fragmentString);
+                    }
+                    for (var param in fragmentParams) {
+                        oauth[param] = fragmentParams[param];
+                    }
+                }
+
+                return oauth;
+            }
+        }
+
+    }
+
+    if ( typeof module === "object" && module && typeof module.exports === "object" ) {
+        module.exports = Keycloak;
+    } else {
+        window.Keycloak = Keycloak;
+
+        if ( typeof define === "function" && define.amd ) {
+            define( "keycloak", [], function () { return Keycloak; } );
+        }
+    }
+})( window );

--- a/lib/ohmage.js
+++ b/lib/ohmage.js
@@ -52,8 +52,8 @@ function Ohmage(app, client){
 		//default parameter
 		data.client = client;
 
-		// add bearer token if keycloak is enabled
-		if (oh.keycloak_enabled && $.cookie("KEYCLOAK_TOKEN")) {
+		// add bearer token for keycloak auth
+		if ($.cookie("KEYCLOAK_TOKEN")) {
 			$.removeCookie("auth_token");
 			headers = {"Authorization": "Bearer "+$.cookie("KEYCLOAK_TOKEN")};
 		// otherwise, add the auth_token cookie as a param.
@@ -382,7 +382,6 @@ function Ohmage(app, client){
 	// test run call
 	oh.config.read().done(function(x){
 		console.log("This is Ohmage/" + x.application_name + " " + x.application_version + " (" + x.application_build + ")")
-		oh.keycloak_enabled = x.keycloak_enabled;
 	}).error(function(msg, code){
 		console.log("Ohmage seems offline: " + msg)
 	});

--- a/lib/ohmage.js
+++ b/lib/ohmage.js
@@ -46,11 +46,18 @@ function Ohmage(app, client){
 		//input processing
 		var data = data || {};
 
+		// construct and pass some headers
+		var headers = {};
+
 		//default parameter
 		data.client = client;
 
-		//add auth_token from cookie
-		if($.cookie('auth_token')){
+		// add bearer token if keycloak is enabled
+		if (oh.keycloak_enabled && $.cookie("KEYCLOAK_TOKEN")) {
+			$.removeCookie("auth_token");
+			headers = {"Authorization": "Bearer "+$.cookie("KEYCLOAK_TOKEN")};
+		// otherwise, add the auth_token cookie as a param.
+		} else if($.cookie('auth_token')){
 			data.auth_token = $.cookie('auth_token');
 		}
 
@@ -58,6 +65,7 @@ function Ohmage(app, client){
 		var req = $.ajax({
 			type: "POST",
 			url : app + path,
+			headers: headers,
 			data: data,
 			dataType: "text",
 			xhrFields: {
@@ -374,6 +382,7 @@ function Ohmage(app, client){
 	// test run call
 	oh.config.read().done(function(x){
 		console.log("This is Ohmage/" + x.application_name + " " + x.application_version + " (" + x.application_build + ")")
+		oh.keycloak_enabled = x.keycloak_enabled;
 	}).error(function(msg, code){
 		console.log("Ohmage seems offline: " + msg)
 	});

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ require.config({
     ohmage: 'lib/ohmage',
     text: 'lib/text',
     async: 'lib/async',
+    keycloak: 'lib/keycloak',
     'jquery.validate': '//cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.14.0/jquery.validate.min',
     'recaptchav1': "https://www.google.com/recaptcha/api/js/recaptcha_ajax"
   },
@@ -23,12 +24,16 @@ require.config({
   	},
     'jquery.validate': {
       deps: ['jquery']
+    },
+    'keycloak': {
+      deps: ['jquery.cookie']
     }
   }
 });
 
 require([
+  'kc',
   'app'
-], function(App){
+], function(kc, App){
   App.initialize();
 });

--- a/oh.js
+++ b/oh.js
@@ -17,6 +17,8 @@ define([
       vent.trigger("ohmage:error:auth", msg, 'danger');
     } else if (msg.match("New accounts aren't allowed to use this service")) {
       vent.trigger("ohmage:error:new_account");
+    } else if (msg.match("auth header")) {
+      //vent.trigger("ohmage:error:new_account");
     } else {
       vent.trigger("ohmage:error", msg, 'danger')
     }

--- a/router.js
+++ b/router.js
@@ -15,13 +15,18 @@ define([
 ], function($, _, Backbone, vent, webToolsView, mobileAppsView, footerView, navbarView, loginView, recoverView, registerView, activationView, iframeView){
   var AppRouter = Backbone.Router.extend({
     routes: {
+      'login?frontend=:foo' : 'showPosts',
       '': 'index',
+
       'login': 'login',
       'recover': 'recover',
       'register': 'register',
       'activate?registration_id=:id': 'index',
-      '*page' : 'pages'
+      '*page' : 'pages',
     },
+    showPosts: function (foo) {
+      console.log("hi");
+    }
   });
 
   var initialize = function(){
@@ -45,6 +50,11 @@ define([
       var navbarview = new navbarView();
       navbarview.render();
     } 
+
+    app_router.on('route:kc', function(queryString, args){
+      console.log('router catches this!');
+      console.log(queryString);
+    })
 
     app_router.on('route:index', function(id){
       $(".display").hide();
@@ -94,6 +104,13 @@ define([
     })
     
     Backbone.history.start();
+
+    if ($.cookie('redirect_to_frontend')) {
+      console.log("boom");
+      var f = $.cookie('redirect_to_frontend');
+      $.removeCookie('redirect_to_frontend');
+      app_router.navigate(f, {trigger: true});
+    }
   };
 
   return {

--- a/templates/login.html
+++ b/templates/login.html
@@ -20,6 +20,18 @@
 		<div class="row">
 			<div class="col-lg-12">
 				<form id="login-form" role="form" style="display: block;">
+          <% if (external) { %>
+          <div class="form-group">
+            <div class="row">
+              <div class="col-sm-8 col-sm-offset-2">
+                <input id="external-auth" tabindex="-1" class="form-control btn btn-register" value="Sign in with external provider">
+              </div>
+            </div>
+          </div>
+          <div class="strike">
+          <span>or</span>
+          </div>
+          <% } %>
 					<div class="form-group">
 						<input type="text" name="username" id="username" tabindex="1" class="form-control" placeholder="Username" value="" required>
 					</div>
@@ -37,10 +49,6 @@
 					  <div class="row">
 					  	<div class="col-lg-12">
 					  		<div class="text-center">
-                  <% if (external) { %>
-                  <a href="#" tabindex="5" class="forgot-password" id="external-auth">Keycloak</a>
-                  <span id="between-links">  | </span>
-                  <% } %>
                   <% if (registration) { %>
                   <a href="#register" tabindex="5" class="forgot-password" id="create-account">Create Account</a>
                   <span id="between-links">  | </span>

--- a/templates/login.html
+++ b/templates/login.html
@@ -37,6 +37,10 @@
 					  <div class="row">
 					  	<div class="col-lg-12">
 					  		<div class="text-center">
+                  <% if (external) { %>
+                  <a href="#" tabindex="5" class="forgot-password" id="external-auth">Keycloak</a>
+                  <span id="between-links">  | </span>
+                  <% } %>
                   <% if (registration) { %>
                   <a href="#register" tabindex="5" class="forgot-password" id="create-account">Create Account</a>
                   <span id="between-links">  | </span>

--- a/views/iframe.js
+++ b/views/iframe.js
@@ -18,6 +18,7 @@ define([
         //a hack to leave the iframe in iframe login. this makes it easier for the clients??
         var iframe_location = iframe[0].contentWindow.location
         if (iframe_location.hash == '#login' && !(iframe_location.href.match(/navbar\/(.*)/))){
+          vent.trigger("route:navlink", 'login');
           vent.trigger('ohmage:error:auth');
           that.iframe_logging_in = true;
         } else {
@@ -35,7 +36,7 @@ define([
       vent.on('iframe:hash', this.hashUpdate, this)
     },
     navigate: function(src){
-      console.log('iframe navigating to: '+src)
+      console.log('iframe navigating to: '+src);
       this.$el.find('#meta_iframe').attr("src", '/navbar/' + src);
     },
     hashUpdate: function(){

--- a/views/login.js
+++ b/views/login.js
@@ -29,7 +29,7 @@ define([
       vent.on('snuff:login', this.undelegate, this);
       vent.on("ohmage:error:new_account", this.forcePasswordChange, this);
       vent.on("updated:password", this.login, this)
-      vent.on("ohmage:error", this.message, this)
+      vent.on("ohmage:error:auth", this.message, this)
       vent.on('ohmage:loggedin', this.logged_in, this);
     },
     events: {
@@ -49,7 +49,7 @@ define([
       oh.login($("#username").val(), $("#password").val()).done(function(token){
         $.cookie("auth_token", token);
         vent.trigger('ohmage:success:auth', $("#username").val());
-        if (document.referrer.split('/')[2] != location.host) { //redirect to home if referrer is unknown.
+        if (document.referrer.split('/')[2] != location.host || window.top.location.hash.substring(1) == 'login') { //redirect to home if referrer is unknown.
           console.log("Referrer appears to be a different host or undefined, ignoring.");
            window.self == window.top ? vent.trigger('route', '') : window.location.replace('/');
         } else { //back to app you came from!
@@ -60,19 +60,6 @@ define([
           window.location.replace(returnTo);
         }
       })
-    },
-    returnToAfterLogin: function(){
-      if (document.referrer.split('/')[2] != location.host) { //redirect to home if referrer is unknown.
-        console.log("Referrer appears to be a different host or undefined, ignoring.");
-         window.self == window.top ? vent.trigger('route', '') : window.location.replace('/');
-      } else { //back to app you came from!
-        //var returnTo = document.referrer.replace(/^[^:]+:\/\/[^/]+/, '').replace(/#.*/, '').replace(/\?.*/, '');
-        // currently ignores the referrer and instead uses the non-iframe location to send the user back there.
-        // this could really use some testing..
-        var returnTo = window.top.location.hash.substring(1)
-        //console.log("redirectUri is: "+returnTo);
-        return returnTo;
-      }      
     },
     forcePasswordChange: function(){
       $("#force-reset-modal").modal("show");

--- a/views/login.js
+++ b/views/login.js
@@ -29,7 +29,7 @@ define([
       vent.on('snuff:login', this.undelegate, this);
       vent.on("ohmage:error:new_account", this.forcePasswordChange, this);
       vent.on("updated:password", this.login, this)
-      vent.on("ohmage:error:auth", this.message, this)
+      vent.on("ohmage:error", this.message, this)
       vent.on('ohmage:loggedin', this.logged_in, this);
     },
     events: {
@@ -49,7 +49,7 @@ define([
       oh.login($("#username").val(), $("#password").val()).done(function(token){
         $.cookie("auth_token", token);
         vent.trigger('ohmage:success:auth', $("#username").val());
-        if (document.referrer.split('/')[2] != location.host || window.top.location.hash.substring(1) == 'login') { //redirect to home if referrer is unknown.
+        if (document.referrer.split('/')[2] != location.host || window.top.location.hash == "#login") { //redirect to home if referrer is unknown.
           console.log("Referrer appears to be a different host or undefined, ignoring.");
            window.self == window.top ? vent.trigger('route', '') : window.location.replace('/');
         } else { //back to app you came from!
@@ -98,7 +98,7 @@ define([
     message: function(msg, status){
       var target = ($("element").data('bs.modal') || {}).isShown ? '.errordiv.reset' : '.errordiv.login'; 
       var template = _.template(messageTemplate);
-      $(target).html(template({status: status, msg: msg})).fadeIn(100);
+      $(target).html(template({status: status, msg: msg})).hide().fadeIn(100);
     },
     undelegate: function(){
       this.undelegateEvents();

--- a/views/login.js
+++ b/views/login.js
@@ -53,11 +53,9 @@ define([
           console.log("Referrer appears to be a different host or undefined, ignoring.");
            window.self == window.top ? vent.trigger('route', '') : window.location.replace('/');
         } else { //back to app you came from!
-          //var returnTo = document.referrer.replace(/^[^:]+:\/\/[^/]+/, '').replace(/#.*/, '').replace(/\?.*/, '');
           // currently ignores the referrer and instead uses the non-iframe location to send the user back there.
           // this could really use some testing..
-          var returnTo = "/navbar/"+window.top.location.hash.substring(1)
-          window.location.replace(returnTo);
+          vent.trigger("route:navlink", window.top.location.hash)
         }
       })
     },
@@ -105,15 +103,8 @@ define([
     },
     keycloakAuth: function(e){
       e.preventDefault();
-      var that = this;
-      var redirectUri = location.origin;
-      if (document.referrer.split('/')[2] != location.host || window.top.location.hash == "#login") { //redirect to home if referrer is unknown.
-        console.log("Referrer appears to be a different host, undefined or unimportant, ignoring.");
-      } else { //back to app you came from!
-        redirectUri = location.origin + "/" + window.top.location.hash; 
-      }
-      console.log("redirectUri is: "+redirectUri);
-      kc.login({redirectUri: redirectUri});
+      $.cookie("redirect_to_frontend", location.hash.substring(1));
+      kc.login({redirectUri: location.href});
     }
   });
   return loginView;

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -41,7 +41,7 @@ define([
         vent.trigger('ohmage:error:auth');
         vent.trigger('route', '');
       });
-      kc.logout();
+      kc.logout({redirectUri: location.origin});
       $.removeCookie("KEYCLOAK_TOKEN");
     },
     logged_out: function(){


### PR DESCRIPTION
A few things that still need to be cleaned up, but I'd like to deploy this to test.mobilizingcs to ensure stable behavior in a pre-2.18/keycloak ohmage.
- once server supports `local_auth: false`, selectively disable local login bits completely (probably easiest to just have the login page immediately direct to keycloak once invoked).
- remove some errant `console.log`s.
